### PR TITLE
Add end-to-end test in Github Actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,41 @@
+name: Lint and Test Chart
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: jainishshah17/tugger
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+
+      - name: Lint Chart
+        run: helm lint chart/*
+
+      - name: Build
+        run: docker build . -t $IMAGE
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+
+      - name: Install
+        run: |
+          kind load docker-image $IMAGE --name=chart-testing
+          helm install $USER chart/tugger --debug --wait \
+            --set=createMutatingWebhook=true \
+            --set=image.tag=latest
+
+      - name: Test Mutation
+        timeout-minutes: 1
+        run: |
+          kubectl apply -f test/nginx.yaml
+          until [ "jainishshah17/nginx" = "$(kubectl -n nginx get po -l test=tugger -o jsonpath='{.items[0].spec.containers[0].image}')" ]
+          do
+            sleep 1
+          done


### PR DESCRIPTION
This adds a workflow that tests `tugger` end-to-end in a kind cluster. It deploys the tugger chart with image mutation enabled, then deploys nginx from the `test` directory, then verifies that the nginx image was rewritten with the default policy. This can be used as a PR status check for basic regression of the service and chart.

Demo available here: https://github.com/infobloxopen/tugger/pull/1/checks