### PR TITLE
Enable Dependabot to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: gomod
+    directory: "/cmd/tugger"
+    schedule:
+      interval: daily


### PR DESCRIPTION
This will create PRs whenever new versions of dependencies are available. Details on this Github feature can be found here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates