### PR TITLE
deduplicate Slack messages to reduce triggering rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ In addition, the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` adm
 
 ```bash
 # Build docker image
-docker build -t jainishshah17/tugger:0.1.0 .
+docker build -t jainishshah17/tugger:0.1.1 .
 
 # Push it to Docker Registry
-docker push jainishshah17/tugger:0.1.0
+docker push jainishshah17/tugger:0.1.1
 ```
 
 ### Create [Kubernetes Docker registry secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)

--- a/chart/tugger/Chart.yaml
+++ b/chart/tugger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.0"
+appVersion: "0.1.1"
 description: A Helm chart for Tugger
 name: tugger
-version: 0.3.1
+version: 0.4.0
 keywords:
 - DevOps
 - helm

--- a/chart/tugger/ci/lint-values.yaml
+++ b/chart/tugger/ci/lint-values.yaml
@@ -17,6 +17,7 @@ rules:
   - pattern: ^jainishshah17/.*
   - pattern: (.*)
     replacement: jainishshah17/$1
+slackDedupeTTL: 24h
 whitelistRegistries:
   - jainishshah17
   - 10.110.50.0:5000

--- a/chart/tugger/templates/deployment.yaml
+++ b/chart/tugger/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             - --policy-file
             - /etc/tugger/policy.yaml
             {{- end }}
+            {{- with .Values.slackDedupeTTL }}
+            - --slack-dedupe-ttl
+            - {{ . }}
+            {{- end }}
           env:
             {{- with .Values.env }}
             - name: ENV

--- a/chart/tugger/values.yaml
+++ b/chart/tugger/values.yaml
@@ -58,6 +58,7 @@ tls:
 
 # Slack webhook URL e.g "https://hooks.slack.com/services/X1234"
 webhookUrl:
+slackDedupeTTL: # default: 3m0s, value must be acceptable to time.ParseDuration() https://golang.org/pkg/time/#ParseDuration
 
 # Optional webhook namespace selector based on labels
 # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector

--- a/cmd/tugger/go.mod
+++ b/cmd/tugger/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-containerregistry v0.2.1
 	github.com/infobloxopen/atlas-app-toolkit v0.22.1
 	github.com/jarcoal/httpmock v1.0.6
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.0

--- a/cmd/tugger/go.sum
+++ b/cmd/tugger/go.sum
@@ -311,6 +311,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -404,31 +404,32 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 // SendSlackNotification will post to an 'Incoming Webook' url setup in Slack Apps. It accepts
 // some text and the slack channel is saved within Slack.
 func SendSlackNotification(msg string) {
-	if webhookUrl != "" {
-		if env != "" {
-			msg = fmt.Sprintf("[%s] %s", env, msg)
-		}
-		slackBody, _ := json.Marshal(SlackRequestBody{Text: msg})
-		req, err := http.NewRequest(http.MethodPost, webhookUrl, bytes.NewBuffer(slackBody))
-		if err != nil {
-			log.WithError(err).Error("unable to build slack request")
-		}
-
-		req.Header.Add("Content-Type", "application/json")
-
-		client := &http.Client{Timeout: 10 * time.Second}
-		resp, err := client.Do(req)
-		if err != nil {
-			log.WithError(err).Error("got error from Slack")
-		}
-
-		buf := new(bytes.Buffer)
-		buf.ReadFrom(resp.Body)
-		if buf.String() != "ok" {
-			log.WithField("resp", buf.String()).Errorln("Non-ok response returned from Slack")
-		}
-		defer resp.Body.Close()
-	} else {
+	if webhookUrl == "" {
 		log.Debugln("Slack Webhook URL is not provided")
+		return
 	}
+
+	if env != "" {
+		msg = fmt.Sprintf("[%s] %s", env, msg)
+	}
+	slackBody, _ := json.Marshal(SlackRequestBody{Text: msg})
+	req, err := http.NewRequest(http.MethodPost, webhookUrl, bytes.NewBuffer(slackBody))
+	if err != nil {
+		log.WithError(err).Error("unable to build slack request")
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.WithError(err).Error("got error from Slack")
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	if buf.String() != "ok" {
+		log.WithField("resp", buf.String()).Errorln("Non-ok response returned from Slack")
+	}
+	defer resp.Body.Close()
 }

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -416,6 +416,7 @@ func SendSlackNotification(msg string) {
 	req, err := http.NewRequest(http.MethodPost, webhookUrl, bytes.NewBuffer(slackBody))
 	if err != nil {
 		log.WithError(err).Error("unable to build slack request")
+		return
 	}
 
 	req.Header.Add("Content-Type", "application/json")
@@ -424,6 +425,7 @@ func SendSlackNotification(msg string) {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.WithError(err).Error("got error from Slack")
+		return
 	}
 
 	buf := new(bytes.Buffer)

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/infobloxopen/atlas-app-toolkit/logging"
+	"github.com/patrickmn/go-cache"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/api/core/v1"
@@ -34,11 +35,13 @@ import (
 )
 
 var (
-	ifExists    bool
-	log         *logrus.Logger
-	policy      *Policy
-	tlsCertFile string
-	tlsKeyFile  string
+	ifExists       bool
+	log            *logrus.Logger
+	policy         *Policy
+	tlsCertFile    string
+	tlsKeyFile     string
+	slackDupeCache *cache.Cache
+	slackDedupeTTL time.Duration
 )
 
 var (
@@ -68,6 +71,7 @@ func main() {
 	policyFile := flag.String("policy-file", "", "YAML file defining allowed image name patterns (see readme)")
 	flag.StringVar(&tlsCertFile, "tls-cert", "/etc/admission-controller/tls/tls.crt", "TLS certificate file.")
 	flag.StringVar(&tlsKeyFile, "tls-key", "/etc/admission-controller/tls/tls.key", "TLS key file.")
+	flag.DurationVar(&slackDedupeTTL, "slack-dedupe-ttl", 3*time.Minute, "drops repeat Slack notifications until this amount of time elapses (requires WEBHOOK_URL defined)")
 	flag.Parse()
 
 	log = logging.New(*logLevel)
@@ -77,6 +81,10 @@ func main() {
 		if policy, err = NewPolicy(WithConfigFile(*policyFile)); err != nil {
 			log.WithError(err).WithField("policy-file", *policyFile).Fatal("failed to load policy file")
 		}
+	}
+
+	if webhookUrl != "" && slackDedupeTTL > 0 {
+		slackDupeCache = cache.New(slackDedupeTTL, 10*time.Minute)
 	}
 
 	http.HandleFunc("/ping", healthCheck)
@@ -412,6 +420,14 @@ func SendSlackNotification(msg string) {
 	if env != "" {
 		msg = fmt.Sprintf("[%s] %s", env, msg)
 	}
+
+	if slackDupeCache != nil {
+		if err := slackDupeCache.Add(msg, struct{}{}, cache.DefaultExpiration); err != nil {
+			log.Info("suppressing duplicate Slack message")
+			return
+		}
+	}
+
 	slackBody, _ := json.Marshal(SlackRequestBody{Text: msg})
 	req, err := http.NewRequest(http.MethodPost, webhookUrl, bytes.NewBuffer(slackBody))
 	if err != nil {

--- a/deployment/tugger-deployment.yaml
+++ b/deployment/tugger-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: tugger
-        image: jainishshah17/tugger:0.1.0
+        image: jainishshah17/tugger:0.1.1
         imagePullPolicy: Always
         env:
           - name: DOCKER_REGISTRY_URL


### PR DESCRIPTION
When tugger is configured to send Slack notifications, it sends a notification every time a pod mutation fails. If a replicaset creates 50 new pods, that results in 50 identical messages. This often triggers Slack's rate limit, and after the first message is not useful.

Example Slack error:
> _Due to a high volume of activity, we are not displaying some messages from this incoming webhook integration._

To reduce this error, I've introduced a Slack message cache to tugger. Now when tugger sends a Slack message, it caches the message. If another pod with the same image is created before the deduplication TTL expires, the Slack message will be suppressed.

This feature defaults the TTL to 3 minutes and can be tuned with the `--slack-dedupe-ttl [DURATION]` flag:
```
  -slack-dedupe-ttl duration
        drops repeat Slack notifications until this amount of time elapses (requires WEBHOOK_URL defined) (default 3m0s)
```
Via the helm chart, it can be configured with the `slackDedupeTTL` value.

When writing the unit tests for this feature, I uncovered a couple nil pointer dereference bugs, and included the fix in this PR.

This PR will be easiest to review one commit at a time -- refactoring and functional changes were kept in separate commits.