### PR TITLE
Fix: mount pull secret whenever present

### DIFF
--- a/chart/tugger/templates/deployment.yaml
+++ b/chart/tugger/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - name: policy
             mountPath: /etc/tugger
           {{- end }}
-          {{- if and .Values.docker.ifExists .Values.image.pullSecret }}
+          {{- if .Values.image.pullSecret }}
           - name: pullsecret
             mountPath: /root/.docker/
           {{- end }}


### PR DESCRIPTION
The "if exists" feature needs an image pull secret to check for images in private repos, or to elevate rate limits before checking for public repos. This feature was previous enabled with the Helm chart value `docker.ifExists`, but now (since #19) can also be enabled as part of a policy in `rules`. This PR fixes the Helm chart logic to mount the pull secret into the pod in both cases.