### PR TITLE
automatically create tag after version bump

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,18 @@
+name: Create Tag
+on:
+  push:
+    branches:
+      - master
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: create tag
+        run: |
+          set -x
+          git fetch --all --tags
+          sudo pip install yq
+          TARGET_TAG=v$(yq .version -r < chart/tugger/Chart.yaml)
+          git tag $TARGET_TAG || exit 0
+          git push origin $TARGET_TAG


### PR DESCRIPTION
I've noticed [some older versions have tags](https://github.com/jainishshah17/tugger/tags), but these haven't been kept up to date recently. This creates a discrepancy between the chart version and the output of `git describe --tags`:
```
% git describe --tags
v0.2.2-47-gfcb0a17
% yq .version -r < chart/tugger/Chart.yaml 
0.4.0
```
You can see git reporting that `master` is based on v0.2.2 while the chart version has been bumped to 0.4.0.

Creating tags can be automated. I've done that in this PR. It will create a tag based on the chart version after each push to master. If the tag already exists, it exits quietly without making any changes.