### PR TITLE
on forks, pull the upstream tag instead of creating a new one

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -6,9 +6,12 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    env:
+      upstream: jainishshah17/tugger
     steps:
       - uses: actions/checkout@v2
       - name: create tag
+        if: github.repository == env.upstream
         run: |
           set -x
           git fetch --all --tags
@@ -16,3 +19,9 @@ jobs:
           TARGET_TAG=v$(yq .version -r < chart/tugger/Chart.yaml)
           git tag $TARGET_TAG || exit 0
           git push origin $TARGET_TAG
+      - name: sync tags
+        if: github.repository != env.upstream
+        run: |
+          set -x
+          git fetch --tags https://github.com/${{ env.upstream }}.git
+          git push --tags


### PR DESCRIPTION
I noticed that the https://github.com/infobloxopen/tugger/ fork had created tags on commits that didn't match https://github.com/jainishshah17/tugger/tags. This PR tweaks the action so that instead of creating tags on forks, the forks will pull the upstream tags.