### PR TITLE
suppress duplicate Slack message only when the original succeeded

### DIFF
--- a/chart/tugger/Chart.yaml
+++ b/chart/tugger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.3"
+appVersion: "0.1.4"
 description: A Helm chart for Tugger
 name: tugger
-version: 0.4.0
+version: 0.4.1
 keywords:
 - DevOps
 - helm

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -209,8 +209,8 @@ func mutateAdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
 				},
 			)
 			patches = append(patches, patch{
-				Op:   "add",
-				Path: "/spec/imagePullSecrets",
+				Op:    "add",
+				Path:  "/spec/imagePullSecrets",
 				Value: imagePullSecrets,
 			})
 		}

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -451,13 +451,16 @@ func SendSlackNotification(msg string) {
 	resp, err := client.Do(req)
 	if err != nil {
 		log.WithError(err).Error("got error from Slack")
+		if slackDupeCache != nil {
+			slackDupeCache.Delete(msg)
+		}
 		return
 	}
+	defer resp.Body.Close()
 
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
 	if buf.String() != "ok" {
 		log.WithField("resp", buf.String()).Errorln("Non-ok response returned from Slack")
 	}
-	defer resp.Body.Close()
 }

--- a/deployment/tugger-deployment.yaml
+++ b/deployment/tugger-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: tugger
-        image: jainishshah17/tugger:0.1.3
+        image: jainishshah17/tugger:0.1.4
         imagePullPolicy: Always
         env:
           - name: DOCKER_REGISTRY_URL


### PR DESCRIPTION
Slack deduplication was added previously with two goals:
* reduce the likelihood of hitting Slack API's rate limit when many pods with the same image start up
* simplify human review of the Slack messages by notifying only once per period per image

The existing logic for Slack message deduplication will suppress messages even when they were not delivered. Naturally, this results in never receiving the message. This accomplishes the goal of avoiding the rate limit, but breaks the feature by not delivering the message.

I've changed the logic here to not de-dupe messages that experience a transport error. Transport errors are likely too early in the chain to count toward Slack API's rate limit. For example, a temporary network outage would result in an error at this point in the code. With the new logic, this will not be cached as a dupe, so the next time tugger makes this substitution, it will now retry the Slack message.

Slack API requests resulting in non-ok response codes maintain their previous behavior, so it won't flood Slack with authentication or rate limit errors.