### PR TITLE
use chart-releaser to create tugger helm chart repo in github pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Create Tag
+name: Release
 on:
   push:
     branches:
@@ -25,3 +25,22 @@ jobs:
           set -x
           git fetch --tags https://github.com/${{ env.upstream }}.git
           git push --tags
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: chart


### PR DESCRIPTION
https://github.com/helm/chart-releaser-action can publish the helm chart to github pages whenever the version number is incremented. 

We can probably remove the `tag` workflow once this is running, but not sure if it completely duplicates it or not.