### PR TITLE
update CI to test currently supported versions of Kubernetes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         k8sVersion:
-          - v1.17.17
-          - v1.18.15
           - v1.19.7
-          - "" # the default version
+          - v1.20.7
+          - v1.21.2
+          - v1.22.1
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -47,7 +47,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         with:
-          node_image: ${{ matrix.k8sVersion && fromJSON('"kindest/node:"') }}${{ matrix.k8sVersion }}
+          node_image: kindest/node:${{ matrix.k8sVersion }}
 
       - name: Install
         run: |


### PR DESCRIPTION
The CI was testing against some older unsupported versions of Kubernetes, so I updated it to the current versions. Also removed the implicit/default version, because it duplicates one of the explicit versions and explicit is preferred.