### PR TITLE
add k8s v1.23 to tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         k8sVersion:
-          - v1.19.7
           - v1.20.7
           - v1.21.2
-          - v1.22.1
+          - v1.22.5
+          - v1.23.3
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
This updates the test matrix to the currently supported versions of Kubernetes, adding v1.23 and removing v1.19.

### Checklist
- [ ] Chart version bumped