### PR TITLE
Update Dockerfile base image to Debian11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./ /src/jainishshah17/tugger/
 RUN cd cmd/tugger && go install
 
 # Runnable image
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian11
 
 # Copy microservice executable from builder image
 COPY --from=builder /go/bin/tugger /

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ In addition, the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` adm
 
 ```bash
 # Build docker image
-docker build -t jainishshah17/tugger:0.1.7 .
+docker build -t jainishshah17/tugger:0.1.8 .
 
 # Push it to Docker Registry
-docker push jainishshah17/tugger:0.1.7
+docker push jainishshah17/tugger:0.1.8
 ```
 
 ### Create [Kubernetes Docker registry secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
@@ -79,7 +79,7 @@ helm install --name tugger \
 	```bash
 	# Run deployment
 	kubectl create -f deployment/tugger-deployment.yaml
-	
+
 	# Create service
 	kubectl create -f  deployment/tugger-svc.yaml
 	```
@@ -90,7 +90,7 @@ helm install --name tugger \
 
 	```bash
 	# re MutatingAdmissionWebhook
-	kubectl create -f webhook/tugger-mutating-webhook ration.yaml 
+	kubectl create -f webhook/tugger-mutating-webhook ration.yaml
 	```
 
 	Note: Use MutatingAdmissionWebhook only if you want to enforce pulling of docker image from Private Docker Registry e.g [JFrog Artifactory](https://jfrog.com/artifactory/).
@@ -98,7 +98,7 @@ helm install --name tugger \
 
 	```bash
 	# Configure ValidatingWebhookConfiguration
-	kubectl create -f webhook/tugger-validating-webhook ration.yaml 
+	kubectl create -f webhook/tugger-validating-webhook ration.yaml
 	```
 
 	Note: Use ValidatingWebhookConfiguration only if you want to check pulling of docker image from Private Docker Registry e.g [JFrog Artifactory](https://jfrog.com/artifactory/).
@@ -107,8 +107,8 @@ helm install --name tugger \
 ### Test Tugger
 
 ```bash
-# Deploy nginx 
-kubectl apply -f test/nginx.yaml 
+# Deploy nginx
+kubectl apply -f test/nginx.yaml
 ```
 
 ## Configure

--- a/chart/tugger/Chart.yaml
+++ b/chart/tugger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.1.7"
+appVersion: "0.1.8"
 description: A Helm chart for Tugger
 name: tugger
-version: 0.4.3
+version: 0.4.4
 keywords:
 - DevOps
 - helm

--- a/deployment/tugger-deployment.yaml
+++ b/deployment/tugger-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: tugger
-        image: jainishshah17/tugger:0.1.7
+        image: jainishshah17/tugger:0.1.8
         imagePullPolicy: Always
         env:
           - name: DOCKER_REGISTRY_URL


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

1. Please describe your change
2. If you made a change in chart/tugger/, please bump the chart version in Chart.yaml.
3. If you made a change to any *.go, please bump the app version and chart version in Chart.yaml.
The version scheme is SemVer: https://semver.org/
-->

The base docker image seems to be out-of-date, and this updates it to the new supported version

### Checklist
- [ ] Chart version bumped