### PR TITLE
Set minimum tls version to 1.3 and statically compile to avoid glibc …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /src/jainishshah17/tugger/
 COPY ./ /src/jainishshah17/tugger/
 
 # Build microservices
-RUN cd cmd/tugger && go install
+RUN cd cmd/tugger && CGO_ENABLED=0 go install -ldflags="-extldflags=-static"
 
 # Runnable image
 FROM gcr.io/distroless/base-debian11

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -96,6 +96,7 @@ func main() {
 		Addr: fmt.Sprintf(":%d", listenPort),
 		TLSConfig: &tls.Config{
 			ClientAuth: tls.NoClientCert,
+			MinVersion: tls.VersionTLS13,
 		},
 	}
 	log.Fatal(s.ListenAndServeTLS(tlsCertFile, tlsKeyFile))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

1. Please describe your change
2. If you made a change in chart/tugger/, please bump the chart version in Chart.yaml.
3. If you made a change to any *.go, please bump the app version and chart version in Chart.yaml.
The version scheme is SemVer: https://semver.org/
-->

- Set webhook server minimum TLS version to 1.3 -- available since Kubenetes 1.13 https://go.dev/doc/go1.13#tls_1_3
  TLS 1.0 was flagged by Nessus: https://www.tenable.com/plugins/nessus/104743
  Verified with nmap
  ```
  > kubectl port-forward tugger-694c8d768c-cp8m6 8443:443
  > nmap --script ssl-enum-ciphers 127.0.0.1 -p 8443
  Starting Nmap 7.94 ( https://nmap.org ) at 2023-08-18 10:34 PDT
  Nmap scan report for localhost (127.0.0.1)
  Host is up (0.00017s latency).

  PORT     STATE SERVICE
  8443/tcp open  https-alt
  | ssl-enum-ciphers:
  |   TLSv1.3:
  |     ciphers:
  |       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
  |       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
  |       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
  |     cipher preference: server
  |_  least strength: A

  Nmap done: 1 IP address (1 host up) scanned in 1.93 seconds
  ```
- Statically compile tugger to avoid missing GLIBC error

### Checklist
- [ ] Chart version bumped