### PR TITLE
set failure policy to be configurable for webhooks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           kind load docker-image $IMAGE --name=chart-testing
           helm install $USER chart/tugger --debug --wait \
-            --set=createMutatingWebhook=true \
+            --set=mutatingWebhook.create=true \
             --set=image.tag=latest
 
       - name: Test Mutation

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ helm install --name tugger \
   --set docker.registryUrl=jainishshah17, \
   --set whitelistNamespaces={kube-system,default}, \
   --set whitelistRegistries={jainishshah17} \
-  --set createValidatingWebhook=true \
-  --set createMutatingWebhook=true \
+  --set validatingWebhook.create=true \
+  --set mutatingWebhook.create=true \
   tugger/tugger
 ```
 

--- a/chart/tugger/Chart.yaml
+++ b/chart/tugger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1.8"
 description: A Helm chart for Tugger
 name: tugger
-version: 0.4.5
+version: 0.4.6
 keywords:
 - DevOps
 - helm

--- a/chart/tugger/ci/lint-values.yaml
+++ b/chart/tugger/ci/lint-values.yaml
@@ -1,6 +1,8 @@
 # enables optional features in the chart so they will be linted in the PR test
-createValidatingWebhook: true
-createMutatingWebhook: true
+validatingWebhook:
+  create: true
+mutatingWebhook:
+  create: true
 env: prod
 docker:
   ifExists: true

--- a/chart/tugger/templates/admission-registration.yaml
+++ b/chart/tugger/templates/admission-registration.yaml
@@ -13,7 +13,7 @@
   {{ $caCert = $ca.Cert }}
 {{- end }}
 
-{{- if .Values.validatingWebhook.create}}
+{{- if or .Values.createValidatingWebhook .Values.validatingWebhook.create}}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -52,7 +52,7 @@ webhooks:
     caBundle: {{ b64enc $caCert }}
 {{- end }}
 
-{{- if .Values.mutatingWebhook.create }}
+{{- if or .Values.createMutatingWebhook .Values.mutatingWebhook.create }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/chart/tugger/templates/admission-registration.yaml
+++ b/chart/tugger/templates/admission-registration.yaml
@@ -13,7 +13,7 @@
   {{ $caCert = $ca.Cert }}
 {{- end }}
 
-{{- if .Values.createValidatingWebhook }}
+{{- if .Values.validatingWebhook.create}}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -42,7 +42,7 @@ webhooks:
     resources:
     - pods
     scope: "Namespaced"
-  failurePolicy: Ignore
+  failurePolicy: {{ default "Ignore" .Values.validatingWebhook.failurePolicy }}
   clientConfig:
     service:
       name: {{ $serviceName }}
@@ -52,7 +52,7 @@ webhooks:
     caBundle: {{ b64enc $caCert }}
 {{- end }}
 
-{{- if .Values.createMutatingWebhook }}
+{{- if .Values.mutatingWebhook.create }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -76,7 +76,7 @@ webhooks:
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]
-  failurePolicy: Ignore
+  failurePolicy: {{ default "Ignore" .Values.mutatingWebhook.failurePolicy }}
   clientConfig:
     service:
       name: {{ $serviceName }}

--- a/chart/tugger/values.yaml
+++ b/chart/tugger/values.yaml
@@ -70,8 +70,12 @@ namespaceSelector:
   #   operator: NotIn
   #   values: ["0","1"]
 
-createValidatingWebhook: false
-createMutatingWebhook: false
+validatingWebhook:
+  create: false
+  failurePolicy: #default: Ignore, options: Ignore, Fail
+mutatingWebhook:
+  create: false
+  failurePolicy: #default: Ignore, options: Ignore, Fail
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

1. Please describe your change
2. If you made a change in chart/tugger/, please bump the chart version in Chart.yaml.
3. If you made a change to any *.go, please bump the app version and chart version in Chart.yaml.
The version scheme is SemVer: https://semver.org/
-->

I would like to be able to fully block the api request if this fails. We have an isolated environment and it would be nice to have an explicit failure if the webhook has issues rather than sending the request on to a messed up container URL, usually resulting in a lot of ImagePullBackoffs.


-- I've added a value to the template that will default to Ignore as it was before. 
For consistency I did change the value for creating the webhooks to be nested under validatingWebhook and mutatingWebhook respectively. That does make this change require some values to be changed before re deploying the helm chart. I can revert that if need be or make a larger version bump. 
### Checklist
- [x ] Chart version bumped