### PR TITLE
Add pod-level skip annotation for Tugger webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ _condition_ is a special condition to test before committing the replacement. In
 
 Each rule will be evaluated in order, and if the list is exhausted without a match, the admission controller will return `allowed: false`.
 
+### Per-pod emergency bypass
+
+If you need to temporarily bypass Tugger for a specific pod, add annotation `tugger.io/skip: "true"` on that pod template. When set to one of `true`, `1`, or `yes`, Tugger will skip both mutation and validation for that pod while keeping namespace-level policies unchanged.
+
 ### Examples
 
 This example allows all images without rewriting:

--- a/cmd/tugger/main.go
+++ b/cmd/tugger/main.go
@@ -66,6 +66,8 @@ type SlackRequestBody struct {
 	Text string `json:"text"`
 }
 
+const skipValidationAnnotation = "tugger.io/skip"
+
 func main() {
 	flag.BoolVar(&ifExists, "if-exists", false, "makes the mutation conditional on whether the mutated image name exists in the registry")
 	logLevel := flag.String("log-level", "info", "log verbosity")
@@ -135,6 +137,12 @@ func mutateAdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
 			log.WithError(err).WithField("object", ar.Request.Object.Raw).Error("could unmarshal pod spec")
 			w.WriteHeader(http.StatusBadRequest)
 			return
+		}
+
+		if shouldSkipPod(pod.ObjectMeta.Annotations) {
+			admissionResponse.Allowed = true
+			log.Printf("Skipping mutation for pod %s/%s due to annotation %q", namespace, pod.Name, skipValidationAnnotation)
+			goto done
 		}
 
 		// Handle Containers
@@ -237,6 +245,7 @@ func mutateAdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
 		admissionResponse.PatchType = &pt
 	}
 
+done:
 	ar = v1beta1.AdmissionReview{
 		Response: &admissionResponse,
 	}
@@ -336,6 +345,12 @@ func validateAdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if shouldSkipPod(pod.ObjectMeta.Annotations) {
+			log.Printf("Skipping validation for pod %s/%s due to annotation %q", namespace, pod.Name, skipValidationAnnotation)
+			admissionResponse.Allowed = true
+			goto done
+		}
+
 		var validateImage func(string) bool
 		if policy != nil {
 			validateImage = policy.ValidateImage
@@ -414,6 +429,20 @@ func containsRegisty(arr []string, str string) bool {
 		}
 	}
 	return false
+}
+
+func shouldSkipPod(annotations map[string]string) bool {
+	if len(annotations) == 0 {
+		return false
+	}
+
+	skipValue, ok := annotations[skipValidationAnnotation]
+	if !ok {
+		return false
+	}
+
+	normalized := strings.TrimSpace(strings.ToLower(skipValue))
+	return normalized == "true" || normalized == "1" || normalized == "yes"
 }
 
 // ping responds to the request with a plain-text "Ok" message.

--- a/cmd/tugger/main_test.go
+++ b/cmd/tugger/main_test.go
@@ -172,6 +172,35 @@ const (
 			}
 		  }
 		}`
+	skipAnnotationAdmissionRequest = `
+	  {
+		  "kind": "AdmissionReview",
+		  "request": {
+			"kind": {
+			  "kind": "Pod",
+			  "version": "v1"
+			},
+			"name": "myapp",
+			"namespace": "foobar",
+			  "object": {
+			  "metadata": {
+				"name": "myapp",
+				"namespace": "foobar",
+				"annotations": {
+				  "tugger.io/skip": "true"
+				}
+			  },
+			  "spec": {
+				"containers": [
+				  {
+					"image": "nginx",
+					"name": "nginx-frontend"
+				  }
+				]
+			  }
+			}
+		  }
+		}`
 )
 
 var (
@@ -226,6 +255,15 @@ var (
 			expectBody:   `{"response":{"uid":"","allowed":true}}`,
 		},
 		{
+			name:         "mutate/skip-annotation",
+			handler:      mutateAdmissionReviewHandler,
+			reqMethod:    "POST",
+			reqPath:      "/mutate",
+			reqBody:      string(skipAnnotationAdmissionRequest),
+			expectStatus: http.StatusOK,
+			expectBody:   `{"response":{"uid":"","allowed":true}}`,
+		},
+		{
 			name:         "validate/untrusted",
 			handler:      validateAdmissionReviewHandler,
 			reqMethod:    "POST",
@@ -258,6 +296,15 @@ var (
 			reqMethod:    "POST",
 			reqPath:      "/validate",
 			reqBody:      string(whitelistedAdmissionRequest),
+			expectStatus: http.StatusOK,
+			expectBody:   `{"response":{"uid":"","allowed":true}}`,
+		},
+		{
+			name:         "validate/skip-annotation",
+			handler:      validateAdmissionReviewHandler,
+			reqMethod:    "POST",
+			reqPath:      "/validate",
+			reqBody:      string(skipAnnotationAdmissionRequest),
 			expectStatus: http.StatusOK,
 			expectBody:   `{"response":{"uid":"","allowed":true}}`,
 		},
@@ -433,6 +480,29 @@ func TestSendSlackNotification(t *testing.T) {
 				webhookUrl = defaultWebhookURL
 			}()
 			SendSlackNotification(tt.msg)
+		})
+	}
+}
+
+func Test_shouldSkipPod(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{name: "no annotations", annotations: nil, want: false},
+		{name: "different annotation", annotations: map[string]string{"foo": "bar"}, want: false},
+		{name: "true value", annotations: map[string]string{skipValidationAnnotation: "true"}, want: true},
+		{name: "one value", annotations: map[string]string{skipValidationAnnotation: "1"}, want: true},
+		{name: "yes value with spaces", annotations: map[string]string{skipValidationAnnotation: " Yes "}, want: true},
+		{name: "false value", annotations: map[string]string{skipValidationAnnotation: "false"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSkipPod(tt.annotations); got != tt.want {
+				t.Errorf("shouldSkipPod() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Motivation
- Provide an emergency per-pod bypass so operators can temporarily opt a single pod out of Tugger mutation/validation without changing namespace policies.

### Description
- Introduce a shared constant `tugger.io/skip` and `shouldSkipPod(annotations map[string]string) bool` helper that treats `true`, `1`, and `yes` (case/space-insensitive) as truthy values.
- Short-circuit both `/mutate` and `/validate` handlers to allow the pod when the skip annotation is present and truthy.
- Add test fixtures and test cases to cover mutate/validate behavior when the skip annotation is present, and add unit tests for `shouldSkipPod`.
- Document the new "Per-pod emergency bypass" behavior in the README.

### Testing
- Ran `go test -run 'TestHandler|Test_shouldSkipPod' ./... -count=1`, and those tests passed.
- Ran `go test ./... -count=1` which fails in this environment due to existing policy tests that attempt remote Docker registry access and receive `Forbidden`, unrelated to the new skip-annotation logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce8ae5ac883218ee776f6616b3ab1)